### PR TITLE
Fix bug related with standalone exporters

### DIFF
--- a/tasks/_service.yml
+++ b/tasks/_service.yml
@@ -58,5 +58,5 @@
       include_tasks: _setup_client_tgroup.yml
   when:
     - prometheus_exporter|bool
-    - prometheus_servers|list
     - prometheus_manage_client_tgroups|bool
+    - prometheus_servers|list


### PR DESCRIPTION
```
---
- name: Install Node Exporter
  hosts: servers
  roles:
    - role: mesaguy.prometheus
      vars:
        prometheus_manage_client_tgroups: false
        prometheus_components:
          - node_exporter
```
I cannot install only the `node exporter`.