### PR TITLE
Add powerdns_exporter_ledgr

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,8 @@ All exporters are verified to install. Currently select modules receive testing 
 |[influxdb_exporter](https://github.com/prometheus/influxdb_exporter)                           | [usage](#influxdb-exporter-configuration)                   | prometheus    | Yes       |
 |[iptables_exporter_retailnext](https://github.com/retailnext/iptables_exporter)                | [usage](#iptables-exporter-retailnext-configuration)        | retailnext    | Yes       |
 |[jmx_exporter](https://github.com/prometheus/jmx_exporter)                                     | [usage](#jmx-exporter-configuration)                        | prometheus    | No        |
-|[kafka_exporter_danielqsj](https://github.com/danielqsj/kafka_exporter)                                  | [usage](#kafka-exporter-danielqsj-configuration)            | danielqsj     | Yes       |
-|[memcached_exporter](https://github.com/prometheus/memcached_exporter)               | [usage](#memcached-exporter-configuration)                  | prometheus    | Yes       |
+|[kafka_exporter_danielqsj](https://github.com/danielqsj/kafka_exporter)                        | [usage](#kafka-exporter-danielqsj-configuration)            | danielqsj     | Yes       |
+|[memcached_exporter](https://github.com/prometheus/memcached_exporter)                         | [usage](#memcached-exporter-configuration)                  | prometheus    | Yes       |
 |[mysqld_exporter](https://github.com/prometheus/mysqld_exporter)                               | [usage](#mysqld-exporter-configuration)                     | prometheus    | Yes       |
 |[node_exporter](https://github.com/prometheus/node_exporter)                                   | [usage](#node-exporter-configuration)                       | prometheus    | Yes       |
 |[ntp_exporter_sapcc](https://github.com/sapcc/ntp_exporter)                                    | [usage](#ntp-exporter-sapcc-configuration)                  | sapcc         | Yes       |
@@ -72,6 +72,7 @@ All exporters are verified to install. Currently select modules receive testing 
 |[openvpn_exporter_kumina](https://github.com/kumina/openvpn_exporter)                          | [usage](#openvpn-exporter-kumina-configuration)             | kumina        | Yes       |
 |[ping_exporter_czerwonk](https://github.com/czerwonk/ping_exporter)                            | [usage](#ping-exporter-czerwonk-configuration)              | czerwonk      | Yes       |
 |[postgres_exporter_wrouesnel](https://github.com/wrouesnel/postgres_exporter)                  | [usage](#proxysql-exporter-percona-configuration)           | wrouesnel     | Yes       |
+|[powerdns_exporter_ledgr](https://github.com/ledgr/powerdns_exporter)                          | [usage](#powerdns-exporter-ledgr-configuration)             | ledgr         | No        |
 |[process_exporter_ncabatoff](https://github.com/ncabatoff/process-exporter)                    | [usage](#process-exporter-ncabatoff-configuration)          | ncabatoff     | Yes       |
 |[proxysql_exporter_percona](https://github.com/percona/proxysql_exporter)                      | [usage](#proxysql-exporter-percona-configuration)           | percona       | Yes       |
 |[rabbitmq_exporter_kbudde](https://github.com/kbudde/rabbitmq_exporter)                        | [usage](#rabbitmq-exporter-kbudde-configuration)            | kbudde        | Yes       |
@@ -1259,6 +1260,16 @@ Port and IP to listen on. Defaults to listening on all available IPs on port 420
 
     prometheus_proxysql_exporter_percona_host: "0.0.0.0"
     prometheus_proxysql_exporter_percona_port: 42004
+
+### Powerdns exporter (ledgr) configuration
+
+To enable [powerdns_exporter_ledgr](https://github.com/ledgr/powerdns_exporter), include the role task: `powerdns_exporter_ledgr`
+
+Powerdns setup requires webserver and API options to be set, see README in that repo.
+
+The following options are configurable for the api_url and api_key needed to connect to the powerdns api. 
+    prometheus_powerdns_exporter_ledgr_api_url: '{{prometheus_powerdns_exporter_ledgr_api_url | default("http://localhost:8081/api/v1/") }}'
+    prometheus_powerdns_exporter_ledgr_api_key: '{{prometheus_powerdns_exporter_ledgr_api_key | default("") }}'
 
 ### RabbitMQ exporter (kbudde) configuration
 

--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ To enable [powerdns_exporter_ledgr](https://github.com/ledgr/powerdns_exporter),
 Powerdns setup requires webserver and API options to be set, see README in that repo.
 
 The following options are configurable for the api_url and api_key needed to connect to the powerdns api. 
+
     prometheus_powerdns_exporter_ledgr_api_url: '{{prometheus_powerdns_exporter_ledgr_api_url | default("http://localhost:8081/api/v1/") }}'
     prometheus_powerdns_exporter_ledgr_api_key: '{{prometheus_powerdns_exporter_ledgr_api_key | default("") }}'
 

--- a/tasks/powerdns_exporter_ledgr.yml
+++ b/tasks/powerdns_exporter_ledgr.yml
@@ -1,8 +1,10 @@
+# powerdns will have a native built-in exporter as of v4.3.0 apparently, so this is for earlier versions!
 ---
 - block:
   - name: Include role mesaguy.prometheus setup task
     include_tasks: _setup.yml
   when: prometheus_setup_task_executed is not defined
+
 
 - name: Include powerdns_exporter (ledgr) variable file
   include_vars: exporters/powerdns_exporter_ledgr.yml
@@ -14,10 +16,10 @@
     prometheus_software_env_vars: '{{ prometheus_powerdns_exporter_ledgr_env_vars | default({}) }}'
     prometheus_software_extra_opts: '{{ prometheus_powerdns_exporter_ledgr_extra_opts | default() }}'
     prometheus_software_fallback_to_build: '{{ prometheus_powerdns_exporter_ledgr_fallback_to_build | default(prometheus_fallback_to_build) }}'
-    prometheus_software_make_command: 'go run mage.go binary'
-    prometheus_software_makefile_make_command: 'go run mage.go binary'
+    # prometheus_software_make_command: 'make'
+    # prometheus_software_makefile_make_command: 'make'
     prometheus_software_name: 'powerdns_exporter_ledgr'
-    # prometheus_software_version: '{{ prometheus_powerdns_exporter_ledgr_version | default("0.8.0") }}'
+    prometheus_software_version: '{{ prometheus_powerdns_exporter_ledgr_version | default("master") }}'
     # prometheus_software_src_version: '{{ prometheus_powerdns_exporter_ledgr_src_version | default("v0.8.0") }}'
     prometheus_software_tgroup_jobname: '{{ prometheus_powerdns_exporter_ledgr_jobname | default(prometheus_powerdns_exporter_ledgr_default_tgroup_jobname) }}'
     prometheus_software_description: 'Prometheus powerdns_exporter (ledgr), exporter of host statistics'
@@ -26,14 +28,17 @@
     prometheus_software_port: '{{ prometheus_powerdns_exporter_ledgr_port | default(prometheus_powerdns_exporter_ledgr_default_port) }}'
     prometheus_software_runas: '{{ prometheus_powerdns_exporter_ledgr_runas | default(prometheus_user) }}'
     prometheus_software_shortname: 'powerdns_exporter'
+    prometheus_powerdns_exporter_ledgr_api_url: '{{prometheus_powerdns_exporter_ledgr_api_url | default("http://localhost:8081/api/v1/") }}'
+    prometheus_powerdns_exporter_ledgr_api_key: '{{prometheus_powerdns_exporter_ledgr_api_key | default("") }}'
 
+- debug:
+    var: prometheus_powerdns_exporter_ledgr_api_key
 
 - name: Set {{ prometheus_software_name }}-{{ prometheus_software_version }} facts
   set_fact:
     prometheus_software_opts:
       - '--listen-address={{ prometheus_software_host }}:{{ prometheus_software_port }} --api-url={{prometheus_powerdns_exporter_ledgr_api_url}} --api-key={{prometheus_powerdns_exporter_ledgr_api_key}}'
     prometheus_software_name_version: '{{ prometheus_software_name }}-{{ prometheus_software_version }}'
-    # prometheus_software_bin_url: 'https://github.com/ledgr/{{ prometheus_software_shortname }}/releases/download/v{{ prometheus_software_version }}/{{ prometheus_software_shortname }}_v{{ prometheus_software_version }}_{{ prometheus_architecture }}.tar.gz'
     prometheus_software_src_dir_suffix: '/src/github.com/ledgr/{{ prometheus_software_shortname }}'
     prometheus_software_src_url: 'https://github.com/ledgr/{{ prometheus_software_shortname }}.git'
 

--- a/tasks/powerdns_exporter_ledgr.yml
+++ b/tasks/powerdns_exporter_ledgr.yml
@@ -1,0 +1,47 @@
+---
+- block:
+  - name: Include role mesaguy.prometheus setup task
+    include_tasks: _setup.yml
+  when: prometheus_setup_task_executed is not defined
+
+- name: Include powerdns_exporter (ledgr) variable file
+  include_vars: exporters/powerdns_exporter_ledgr.yml
+
+- name: Starting powerdns_exporter (ledgr) install
+  set_fact:
+    prometheus_exporter: true
+    prometheus_software_binary_name: 'powerdns_exporter'
+    prometheus_software_env_vars: '{{ prometheus_powerdns_exporter_ledgr_env_vars | default({}) }}'
+    prometheus_software_extra_opts: '{{ prometheus_powerdns_exporter_ledgr_extra_opts | default() }}'
+    prometheus_software_fallback_to_build: '{{ prometheus_powerdns_exporter_ledgr_fallback_to_build | default(prometheus_fallback_to_build) }}'
+    prometheus_software_make_command: 'go run mage.go binary'
+    prometheus_software_makefile_make_command: 'go run mage.go binary'
+    prometheus_software_name: 'powerdns_exporter_ledgr'
+    # prometheus_software_version: '{{ prometheus_powerdns_exporter_ledgr_version | default("0.8.0") }}'
+    # prometheus_software_src_version: '{{ prometheus_powerdns_exporter_ledgr_src_version | default("v0.8.0") }}'
+    prometheus_software_tgroup_jobname: '{{ prometheus_powerdns_exporter_ledgr_jobname | default(prometheus_powerdns_exporter_ledgr_default_tgroup_jobname) }}'
+    prometheus_software_description: 'Prometheus powerdns_exporter (ledgr), exporter of host statistics'
+    prometheus_software_documentation: 'https://github.com/ledgr/powerdns_exporter'
+    prometheus_software_host: '{{ prometheus_powerdns_exporter_ledgr_host | default("0.0.0.0") }}'
+    prometheus_software_port: '{{ prometheus_powerdns_exporter_ledgr_port | default(prometheus_powerdns_exporter_ledgr_default_port) }}'
+    prometheus_software_runas: '{{ prometheus_powerdns_exporter_ledgr_runas | default(prometheus_user) }}'
+    prometheus_software_shortname: 'powerdns_exporter'
+
+
+- name: Set {{ prometheus_software_name }}-{{ prometheus_software_version }} facts
+  set_fact:
+    prometheus_software_opts:
+      - '--listen-address={{ prometheus_software_host }}:{{ prometheus_software_port }} --api-url={{prometheus_powerdns_exporter_ledgr_api_url}} --api-key={{prometheus_powerdns_exporter_ledgr_api_key}}'
+    prometheus_software_name_version: '{{ prometheus_software_name }}-{{ prometheus_software_version }}'
+    # prometheus_software_bin_url: 'https://github.com/ledgr/{{ prometheus_software_shortname }}/releases/download/v{{ prometheus_software_version }}/{{ prometheus_software_shortname }}_v{{ prometheus_software_version }}_{{ prometheus_architecture }}.tar.gz'
+    prometheus_software_src_dir_suffix: '/src/github.com/ledgr/{{ prometheus_software_shortname }}'
+    prometheus_software_src_url: 'https://github.com/ledgr/{{ prometheus_software_shortname }}.git'
+
+- name: Include task to perform installation of {{ prometheus_software_name_version }}
+  include_tasks: _install.yml
+
+- name: Include task to setup {{ prometheus_software_name_version }} service
+  include_tasks: _service.yml
+
+- name: Include task to perform post install cleanup of {{ prometheus_software_name_version }}
+  include_tasks: _post_install_cleanup.yml

--- a/vars/exporters/powerdns_exporter_ledgr.yml
+++ b/vars/exporters/powerdns_exporter_ledgr.yml
@@ -1,5 +1,5 @@
 ---
-prometheus_powerdns_exporter_ledgr_listen_address: 9120
+prometheus_powerdns_exporter_ledgr_default_port: 9120
 prometheus_powerdns_exporter_ledgr_default_tgroup_jobname: powerdns
 prometheus_powerdns_exporter_ledgr_metric_path: /metrics
 prometheus_powerdns_exporter_ledgr_api_url: http://localhost:8081/api/v1/

--- a/vars/exporters/powerdns_exporter_ledgr.yml
+++ b/vars/exporters/powerdns_exporter_ledgr.yml
@@ -1,0 +1,6 @@
+---
+prometheus_powerdns_exporter_ledgr_listen_address: 9120
+prometheus_powerdns_exporter_default_tgroup_jobname: powerdns
+prometheus_powerdns_exporter_ledgr_metric_path: /metrics
+prometheus_powerdns_exporter_ledgr_api_url: http://localhost:8081/api/v1/
+prometheus_powerdns_exporter_ledgr_api_key: null

--- a/vars/exporters/powerdns_exporter_ledgr.yml
+++ b/vars/exporters/powerdns_exporter_ledgr.yml
@@ -1,6 +1,6 @@
 ---
 prometheus_powerdns_exporter_ledgr_listen_address: 9120
-prometheus_powerdns_exporter_default_tgroup_jobname: powerdns
+prometheus_powerdns_exporter_ledgr_default_tgroup_jobname: powerdns
 prometheus_powerdns_exporter_ledgr_metric_path: /metrics
 prometheus_powerdns_exporter_ledgr_api_url: http://localhost:8081/api/v1/
 prometheus_powerdns_exporter_ledgr_api_key: null

--- a/vars/exporters/powerdns_exporter_ledgr.yml
+++ b/vars/exporters/powerdns_exporter_ledgr.yml
@@ -1,6 +1,3 @@
 ---
 prometheus_powerdns_exporter_ledgr_default_port: 9120
 prometheus_powerdns_exporter_ledgr_default_tgroup_jobname: powerdns
-prometheus_powerdns_exporter_ledgr_metric_path: /metrics
-prometheus_powerdns_exporter_ledgr_api_url: http://localhost:8081/api/v1/
-prometheus_powerdns_exporter_ledgr_api_key: null


### PR DESCRIPTION
Added some config and was able to get this exporter from https://github.com/ledgr/powerdns_exporter to work without too much hassle. This exporter is linked off of https://prometheus.io/docs/instrumenting/exporters/  for powerdns.  

I am not sure what kitchen is or how the tests are setup, but this seems to work fine on the Cent7 host I am working with. 