### PR TITLE
support env files for services

### DIFF
--- a/tasks/_service.yml
+++ b/tasks/_service.yml
@@ -7,6 +7,20 @@
     owner: root
     group: '{{ prometheus_group }}'
 
+- name: Create environment file for {{ prometheus_software_service_name }} service
+  become: true
+  template:
+    dest: '{{ prometheus_etc_dir }}/{{ prometheus_software_service_name }}.env'
+    src: ../templates/daemon-env.j2
+    owner: root
+    group: root
+    mode: '0640'
+  notify:
+    - name: Force systemd to reread configs
+      when: ansible_service_mgr == "systemd"
+    - Restart Prometheus service
+  when: prometheus_software_env_vars is defined and prometheus_software_env_vars
+
 - name: Include task to setup {{ prometheus_software_name_version }} {{ ansible_service_mgr }} service
   include_tasks: '_service_mgr_{{ ansible_service_mgr | regex_replace("^(openrc|upstart)$", "init") }}.yml'
 

--- a/templates/daemon-env.j2
+++ b/templates/daemon-env.j2
@@ -1,0 +1,8 @@
+#
+# Do not edit manually, this file is managed using automation tools
+#
+{% if prometheus_software_env_vars is defined and prometheus_software_env_vars -%}
+{% for key in prometheus_software_env_vars.keys() -%}
+{{ key }}='{{ prometheus_software_env_vars[key] }}'
+{% endfor -%}
+{% endif -%}

--- a/templates/daemon-systemd.j2
+++ b/templates/daemon-systemd.j2
@@ -19,9 +19,7 @@ LimitNOFILE={{ prometheus_ulimit_hard_nofile }}
 {% endfor -%}
 {% endif -%}
 {% if prometheus_software_env_vars is defined and prometheus_software_env_vars -%}
-{% for key in prometheus_software_env_vars.keys() -%}
-Environment={{ key }}={{ prometheus_software_env_vars[key] }}
-{% endfor -%}
+EnvironmentFile={{ prometheus_etc_dir }}/{{ prometheus_software_service_name }}.env
 {% endif -%}
 User={% if prometheus_software_runas is defined and prometheus_software_runas -%}
 {{ prometheus_software_runas }}

--- a/templates/daemon-upstart.j2
+++ b/templates/daemon-upstart.j2
@@ -51,9 +51,9 @@ umask 022
 
 {% if prometheus_software_env_vars is defined and prometheus_software_env_vars %}
 # Custom environmental variables:
-{% for key in prometheus_software_env_vars.keys() -%}
-export {{ key }}="{{ prometheus_software_env_vars[key] }}"
-{% endfor -%}
+set -a
+. "{{ prometheus_etc_dir }}/{{ prometheus_software_service_name }}.env"
+set +a
 {% endif -%}
 
 {% if prometheus_software_prefix_command is defined and prometheus_software_prefix_command -%}


### PR DESCRIPTION
This is support for environment files. This makes sysv and systemd (not openrc yet) use dedicated environment file with secure permissions (640). Without this any user may see exported variables including passwords stored in the service files for systemd/sysv. Setting permission on the service file itself doesn't  help in case of systemd, since unit configuration may be shown by `systemctl show`. So, this is a generic approach for all init systems.