### PR TITLE
when condition fails when already installed

### DIFF
--- a/tasks/_install_from_binary.yml
+++ b/tasks/_install_from_binary.yml
@@ -181,4 +181,5 @@
   file:
     path: '{{ prometheus_software_archive_file }}'
     state: absent
-  when: prometheus_software_installation is succeeded
+  when:
+    - not prometheus_software_installed.stat.exists and prometheus_software_installation is succeeded


### PR DESCRIPTION
The play is failing on the `when` condition of `prometheus_software_installation is succeeded`

To prevent that piece of code being executed and causing a failure another precondition in front of that can help.