### PR TITLE
Fix prometheus and alertmanager config permissions

### DIFF
--- a/tasks/alertmanager.yml
+++ b/tasks/alertmanager.yml
@@ -52,8 +52,8 @@
     src: '../templates/generic-config.yml.j2'
     dest: '{{ prometheus_etc_dir }}/alertmanager.yml'
     owner: root
-    group: root
-    mode: '0644'
+    group: '{{ prometheus_group }}'
+    mode: '0640'
     backup: true
     validate: '{{ prometheus_software_install_dir }}/amtool check-config %s'
   notify:

--- a/tasks/blackbox_exporter.yml
+++ b/tasks/blackbox_exporter.yml
@@ -39,8 +39,8 @@
     src: '../templates/blackbox_exporter.yml.j2'
     dest: '{{ prometheus_etc_dir }}/blackbox_exporter.yml'
     owner: root
-    group: root
-    mode: '0644'
+    group: '{{ prometheus_group }}'
+    mode: '0640'
     backup: true
     validate: '{{ prometheus_software_install_dir }}/blackbox_exporter --config.check --config.file %s'
   notify:

--- a/tasks/prometheus.yml
+++ b/tasks/prometheus.yml
@@ -94,7 +94,7 @@
     dest: '{{ prometheus_etc_dir }}/prometheus.yml'
     owner: root
     group: '{{ prometheus_group }}'
-    mode: '0644'
+    mode: '0640'
     backup: true
     validate: '{{ prometheus_software_install_dir }}/promtool check config %s'
   notify:


### PR DESCRIPTION
Prometheus and alertmanager configs may contain sensible data (passwords, tokens) and should not be world-readable.