### PR TITLE
haproxy scrape_uri support and web.listen-address fix

### DIFF
--- a/docs/haproxy_exporter.md
+++ b/docs/haproxy_exporter.md
@@ -19,9 +19,10 @@ Port and IP to listen on. Defaults to listening on all available IPs on port 910
     prometheus_haproxy_exporter_host: "0.0.0.0"
     prometheus_haproxy_exporter_port: 9101
 
-To gather HAProxy stats via a unix socket, specify the path to the unix socket. Collecting HAProxy stats via the http and unix socket methods are mutually exclusive. It may also be necessary to run the haproxy_exporter as the user haproxy is running as:
+To gather HAProxy stats via a unix socket or non-default uri, specify the path to the unix socket or scrape-uri. Collecting HAProxy stats via the http and unix socket methods are mutually exclusive, scrape-uri overrides socket. It may also be necessary to run the haproxy_exporter as the user haproxy is running as:
 
     prometheus_haproxy_exporter_socket: '/run/haproxy/haproxy.sock'
+    prometheus_haproxy_exporter_scrape_uri: 'http://127.0.0.1:1234/;csv'
     prometheus_haproxy_exporter_runas: haproxy
 
 Enable HAProxy statistics via socket in the HAProxy globals section:

--- a/tasks/haproxy_exporter.yml
+++ b/tasks/haproxy_exporter.yml
@@ -20,11 +20,12 @@
 - name: Set {{ prometheus_software_name_version }} facts
   set_fact:
     prometheus_software_opts: >
-      [{% if prometheus_haproxy_exporter_socket is defined and prometheus_haproxy_exporter_socket %}
-      "--haproxy.scrape-uri=unix:{{ prometheus_haproxy_exporter_socket }}"
-      {% else %}
-      "--web.listen-address={{ prometheus_software_host }}:{{ prometheus_software_port }}"
-      {% endif %}]
+      [{% if prometheus_haproxy_exporter_scrape_uri is defined and prometheus_haproxy_exporter_scrape_uri %}
+      "--haproxy.scrape-uri={{ prometheus_haproxy_exporter_scrape_uri }}",
+      {% elif prometheus_haproxy_exporter_socket is defined and prometheus_haproxy_exporter_socket %}
+      "--haproxy.scrape-uri=unix:{{ prometheus_haproxy_exporter_socket }}",
+      {% endif %}
+      "--web.listen-address={{ prometheus_software_host }}:{{ prometheus_software_port }}"]
     prometheus_software_url:
       "https://github.com/{{ prometheus_software_author }}/{{ prometheus_software_name }}/releases/download/{{ prometheus_software_version }}/\
       {{ prometheus_software_name }}-{{ prometheus_software_version | regex_replace('^(v)?') }}.{{ prometheus_software_architecture }}.tar.gz"


### PR DESCRIPTION
support non-socket haproxy scrape-uri and a fix for web.listen-address which is ignored if the socket is specified.