### PR TITLE
Mask environment configuration with `no_log`

### DIFF
--- a/tasks/_service.yml
+++ b/tasks/_service.yml
@@ -23,6 +23,7 @@
   notify:
     - Restart Prometheus service
   when: prometheus_software_env_vars is defined and prometheus_software_env_vars
+  no_log: True
 
 - name: Include task to setup {{ prometheus_software_name_version }} {{ ansible_service_mgr }} service
   include_tasks: '_service_mgr_{{ ansible_service_mgr | regex_replace("^(openrc|upstart)$", "init") }}.yml'

--- a/tasks/_setup_software_facts.yml
+++ b/tasks/_setup_software_facts.yml
@@ -117,7 +117,6 @@
 - name: Set {{ prometheus_software_name }} generic facts
   set_fact:
     prometheus_software_build_prerequisites: '{{ prometheus_software_os_options.build_prerequisites | default([]) }}'
-    prometheus_software_env_vars: '{{ lookup("vars", "prometheus_" + prometheus_software_name + "_env_vars", default={}) }}'
     prometheus_software_extra_opts: '{{ lookup("vars", "prometheus_" + prometheus_software_name + "_extra_opts", default="") }}'
     prometheus_software_fallback_to_build: >-
       {{ lookup("vars", "prometheus_" + prometheus_software_name + "_fallback_to_build", default=prometheus_fallback_to_build) }}
@@ -141,3 +140,8 @@
       {% endif %}"
     prometheus_software_tgroup_jobname: >-
       {{ lookup("vars", "prometheus_" + prometheus_software_name + "_jobname", default=prometheus_software_default_jobname) }}
+
+- name: Set {{ prometheus_software_name }} sensitive facts
+  set_fact:
+    prometheus_software_env_vars: '{{ lookup("vars", "prometheus_" + prometheus_software_name + "_env_vars", default={}) }}'
+  no_log: true


### PR DESCRIPTION
I ran into this when I was configuring the mongo exporter, it requires me to set credentials via environment variables. 

Environment files are frequently used to inject sensitive values to daemons; this change enables the `no_log` flag on this task.

Alternatively, we could have two tasks that do the same thing and require users to opt out/in perhaps something like this:

```yaml
prometheus_my_exporter_env_vars:
   foo: 'not a secret, i like my diffs'
prometheus_my_exporter_env_insensitive: true
```