### PR TITLE
Let $prog be defined earlier in upstart

### DIFF
--- a/templates/daemon-upstart.j2
+++ b/templates/daemon-upstart.j2
@@ -71,6 +71,7 @@ COMMAND_UNQUOTED="$DAEMON {{ args | join(' ') | replace ('"', "" ) }}"
 COMMAND="$DAEMON"
 COMMAND_UNQUOTED="$DAEMON"
 {% endif -%}
+prog="{{ prometheus_software_name }}"
 {% if installer_instance is defined and installer_instance and installer_instance.name -%}
 export PATH="${PATH:+$PATH:}/usr/sbin:/sbin"
 logfile="{{ prometheus_log_dir }}/{{ prometheus_software_name }}__{{ installer_instance.name }}.log"
@@ -88,7 +89,6 @@ runas_user={% if prometheus_software_runas is defined and prometheus_software_ru
 {% endif -%}
 {% if ansible_os_family == 'RedHat' -%}
 RETVAL=0
-prog="{{ prometheus_software_name }}"
 
 runlevel=$(set -- $(runlevel); eval "echo \$$#" )
 {% if prometheus_software_validation_command is defined and prometheus_software_validation_command %}


### PR DESCRIPTION
Move `prog=` so that it is defined before the `lockfile=` variable is set

Addresses the fact it cannot read it's lockfile, and the (somewhat) terrifying message:

```
[root@example ~]# service mongodb_exporter_percona restart
rm: cannot remove `/var/lock/subsys/': Is a directory      [  OK  ]
```