### PR TITLE
Fixes #43 (add EL9 support)

### DIFF
--- a/vars/os/RedHat-9.yml
+++ b/vars/os/RedHat-9.yml
@@ -1,0 +1,24 @@
+---
+prometheus_shell: /sbin/nologin
+prometheus_capabilites_packages:
+ - which
+prometheus_gnu_time_packages:
+ - time
+prometheus_go_compile_tools:
+ - curl
+ - gcc
+ - git
+ - gzip
+ - make
+prometheus_java_packages:
+ - java-11-openjdk-headless
+prometheus_prerequisite_packages:
+ - tar
+ - unzip
+ - which
+prometheus_sponge_packages:
+ - moreutils
+prometheus_testing_packages:
+ - cronie
+ - net-tools
+ - procps-ng


### PR DESCRIPTION
Add Redhat-9 OS vars, which handle all EL9 variables. 
Tested on 
* Almalinux 9
* Centos 9
