### PR TITLE
swap copy module for template

### DIFF
--- a/tasks/snmp_exporter.yml
+++ b/tasks/snmp_exporter.yml
@@ -47,7 +47,7 @@
 
 - name: Setup {{ prometheus_software_version }} configuration file
   become: true
-  copy:
+  template:
     src: '{{ prometheus_snmp_exporter_yml }}'
     dest: '{{ prometheus_etc_dir }}/snmp_exporter.yml'
     owner: root


### PR DESCRIPTION
Some snmp_exporter configuration files require to have sensitive data, such as for cmc devices. By swapping the copy module on line 50 to template in the snmp_exporter task you can pass passwords and usernames through variables.